### PR TITLE
Update filter placeholder with example input based on default answer

### DIFF
--- a/hooks/use-answer-filter.ts
+++ b/hooks/use-answer-filter.ts
@@ -69,5 +69,12 @@ export function buildFilterPlaceholder(question: WizardQuestion | null) {
     return ""
   }
 
-  return `Filter ${question.answers.length} options`
+  const defaultAnswer = question.answers.find((answer) => answer.isDefault && !answer.disabled)
+  const exampleLabel = defaultAnswer?.label?.trim() || defaultAnswer?.value?.trim()
+
+  if (exampleLabel && exampleLabel.length > 0) {
+    return `Type ${exampleLabel} for example...`
+  }
+
+  return "Type to filter options..."
 }


### PR DESCRIPTION
Enhance the filter placeholder to provide users with an example input derived from the default answer, improving usability and guidance.